### PR TITLE
Add localizations of FormatOptions

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -4,7 +4,11 @@
     "summary": "A reliable way to format dates and times with Elm.",
     "license": "BSD-3-Clause",
     "version": "1.1.0",
-    "exposed-modules": ["DateFormat", "DateFormat.Relative"],
+    "exposed-modules": [
+        "DateFormat",
+        "DateFormat.Relative",
+        "DateFormat.Localized"
+    ],
     "elm-version": "0.19.0 <= v < 0.20.0",
     "dependencies": {
         "elm/core": "1.0.0 <= v < 2.0.0",

--- a/src/DateFormat.elm
+++ b/src/DateFormat.elm
@@ -581,11 +581,9 @@ format =
 
 {-| If our users don't speak English, printing out "Monday" or "Tuesday" might not be a great fit.
 
-Thanks to a great recommendation, `date-format` now supports multilingual output!
-
-All you need to do is provide your own options, and format will use your preferences instead:
-
-For a complete example, check out the [`FormatWithOptions.elm` in the examples folder](https://github.com/ryannhg/date-format/blob/master/examples/FormatWithOptions.elm).
+Thanks to a great recommendation, `date-format` now supports multilingual output! You can find premade formatting for
+some languages in the `DateFormat.Localized` module. All you need to do is provide those or your own options, and
+formatting will use your preferences instead.
 
 -}
 formatWithOptions : FormatOptions -> List Token -> Zone -> Posix -> String
@@ -597,76 +595,7 @@ formatWithOptions options tokens zone time =
 
 {-| These are the available options for formatting our dates.
 
-Here's an example for creating Spanish `FormatOptions`:
-
-    spanishFullMonthName : Time.Month -> String
-    spanishFullMonthName month =
-        case month of
-            Jan ->
-                "Enero"
-
-            Feb ->
-                "Febrero"
-
-            Mar ->
-                "Marzo"
-
-            Apr ->
-                "Abril"
-
-            May ->
-                "Mayo"
-
-            Jun ->
-                "Junio"
-
-            Jul ->
-                "Julio"
-
-            Aug ->
-                "Agosto"
-
-            Sep ->
-                "Septiembre"
-
-            Oct ->
-                "Octubre"
-
-            Nov ->
-                "Noviembre"
-
-            Dec ->
-                "Diciembre"
-
-    spanishDayOfWeekName : Time.Weekday -> String
-    spanishDayOfWeekName weekday =
-        case weekday of
-            Mon ->
-                "Lunes"
-
-            Tue ->
-                "Martes"
-
-            Wed ->
-                "Miércoles"
-
-            Thu ->
-                "Jueves"
-
-            Fri ->
-                "Viernes"
-
-            Sat ->
-                "Sábado"
-
-            Sun ->
-                "Domingo"
-
-    spanishOptions : DateFormat.FormatOptions
-    spanishOptions =
-        { fullMonthName = spanishFullMonthName
-        , dayOfWeekName = spanishDayOfWeekName
-        }
+You can find premade values of this type in the `DateFormat.Localized` module.
 
 -}
 type alias FormatOptions =
@@ -929,6 +858,7 @@ daysInMonth year_ month =
         Feb ->
             if isLeapYear year_ then
                 29
+
             else
                 28
 
@@ -967,10 +897,13 @@ isLeapYear : Int -> Bool
 isLeapYear year_ =
     if modBy 4 year_ /= 0 then
         False
+
     else if modBy 100 year_ /= 0 then
         True
+
     else if modBy 400 year_ /= 0 then
         False
+
     else
         True
 
@@ -1113,6 +1046,7 @@ amPm : Zone -> Posix -> String
 amPm zone posix =
     if Time.toHour zone posix > 11 then
         "pm"
+
     else
         "am"
 
@@ -1125,8 +1059,10 @@ toNonMilitary : Int -> Int
 toNonMilitary num =
     if num == 0 then
         12
+
     else if num <= 12 then
         num
+
     else
         num - 12
 

--- a/src/DateFormat/Localized.elm
+++ b/src/DateFormat/Localized.elm
@@ -1,0 +1,282 @@
+module DateFormat.Localized exposing (spanish)
+
+{-| Format dates in your language!
+
+@docs spanish, french, portuguese, greek
+
+-}
+
+import DateFormat exposing (FormatOptions)
+import Time exposing (Month(..), Weekday(..))
+
+
+{-| Spanish localization.
+-}
+spanish : FormatOptions
+spanish =
+    { fullMonthName =
+        \month ->
+            case month of
+                Jan ->
+                    "Enero"
+
+                Feb ->
+                    "Febrero"
+
+                Mar ->
+                    "Marzo"
+
+                Apr ->
+                    "Abril"
+
+                May ->
+                    "Mayo"
+
+                Jun ->
+                    "Junio"
+
+                Jul ->
+                    "Julio"
+
+                Aug ->
+                    "Agosto"
+
+                Sep ->
+                    "Septiembre"
+
+                Oct ->
+                    "Octubre"
+
+                Nov ->
+                    "Noviembre"
+
+                Dec ->
+                    "Diciembre"
+    , dayOfWeekName =
+        \weekday ->
+            case weekday of
+                Mon ->
+                    "Lunes"
+
+                Tue ->
+                    "Martes"
+
+                Wed ->
+                    "Miércoles"
+
+                Thu ->
+                    "Jueves"
+
+                Fri ->
+                    "Viernes"
+
+                Sat ->
+                    "Sábado"
+
+                Sun ->
+                    "Domingo"
+    }
+
+
+{-| French localization
+-}
+french : FormatOptions
+french =
+    { fullMonthName =
+        \month ->
+            case month of
+                Jan ->
+                    "Janvier"
+
+                Feb ->
+                    "Février"
+
+                Mar ->
+                    "Mars"
+
+                Apr ->
+                    "Avril"
+
+                May ->
+                    "Mai"
+
+                Jun ->
+                    "Juin"
+
+                Jul ->
+                    "Juillet"
+
+                Aug ->
+                    "Août"
+
+                Sep ->
+                    "Septembre"
+
+                Oct ->
+                    "Octobre"
+
+                Nov ->
+                    "Novembre"
+
+                Dec ->
+                    "Décembre"
+    , dayOfWeekName =
+        \weekday ->
+            case weekday of
+                Mon ->
+                    "Lundi"
+
+                Tue ->
+                    "Mardi"
+
+                Wed ->
+                    "Mercredi"
+
+                Thu ->
+                    "Jeudi"
+
+                Fri ->
+                    "Vendredi"
+
+                Sat ->
+                    "Samedi"
+
+                Sun ->
+                    "Dimanche"
+    }
+
+
+{-| Portugeuse (and Brazillian) localization.
+-}
+portuguese : FormatOptions
+portuguese =
+    { fullMonthName =
+        \month ->
+            case month of
+                Jan ->
+                    "Janeiro"
+
+                Feb ->
+                    "Fevereiro"
+
+                Mar ->
+                    "Março"
+
+                Apr ->
+                    "Abril"
+
+                May ->
+                    "Maio"
+
+                Jun ->
+                    "Junho"
+
+                Jul ->
+                    "Julho"
+
+                Aug ->
+                    "Agosto"
+
+                Sep ->
+                    "Setembro"
+
+                Oct ->
+                    "Outubro"
+
+                Nov ->
+                    "Novembro"
+
+                Dec ->
+                    "Dezembro"
+    , dayOfWeekName =
+        \weekday ->
+            case weekday of
+                Mon ->
+                    "Segunda-feira"
+
+                Tue ->
+                    "Terça-feira"
+
+                Wed ->
+                    "Quarta-feira"
+
+                Thu ->
+                    "Quinta-feira"
+
+                Fri ->
+                    "Sexta-feira"
+
+                Sat ->
+                    "Sábado"
+
+                Sun ->
+                    "Domingo"
+    }
+
+
+{-| Greek localization.
+-}
+greek : FormatOptions
+greek =
+    { fullMonthName =
+        \month ->
+            case month of
+                Jan ->
+                    "Ιανουαρίου"
+
+                Feb ->
+                    "Φεβρουαρίου"
+
+                Mar ->
+                    "Μαρτίου"
+
+                Apr ->
+                    "Απριλίου"
+
+                May ->
+                    "Μαΐου"
+
+                Jun ->
+                    "Ιουνίου"
+
+                Jul ->
+                    "Ιουλίου"
+
+                Aug ->
+                    "Αυγούστου"
+
+                Sep ->
+                    "Σεπτεμβρίου"
+
+                Oct ->
+                    "Οκτωβρίου"
+
+                Nov ->
+                    "Νοεμβρίου"
+
+                Dec ->
+                    "Δεκεμβρίου"
+    , dayOfWeekName =
+        \weekday ->
+            case weekday of
+                Mon ->
+                    "Δευτέρα"
+
+                Tue ->
+                    "Τρίτη"
+
+                Wed ->
+                    "Τετάρτη"
+
+                Thu ->
+                    "Πέμπτη"
+
+                Fri ->
+                    "Παρασκευή"
+
+                Sat ->
+                    "Σάββατο"
+
+                Sun ->
+                    "Κυριακή"
+    }


### PR DESCRIPTION
Spanish comes from the comments; the rest are from my library.

There are a number of places you can go from here:
* Including month and weekday abbreivations
* Including AM/PM translations
* Including number suffix translations (you don't say 1st in French)
* Including more languages
* Possibly using records instead of functions

But I think this is a good start.