### PR TITLE
Add tests for relative time, and fix them

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,15 +22,10 @@ before_install:
 
 
 install:
-  - npm install -g elm@0.19.0 elm-test@0.19.0-beta4 elm-format@0.8.0-rc3
-  - mv $(npm config get prefix)/bin/elm-make $(npm config get prefix)/bin/elm-make-old
-  - printf '%s\n\n' '#!/bin/bash' 'echo "Running elm-make with sysconfcpus -n 2"' '$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-make-old "$@"' > $(npm config get prefix)/bin/elm-make
-  - chmod +x $(npm config get prefix)/bin/elm-make
-  - travis_retry elm-package install --yes
-  - cd tests
-  - npm install
-  - travis_retry elm-package install --yes
-  - cd ..
+  - npm install -g elm@0.19.0 elm-test@0.19.0-beta9 elm-format@0.8.0
+  - mv $(npm config get prefix)/bin/elm $(npm config get prefix)/bin/elm-old
+  - printf '%s\n\n' '#!/bin/bash' 'echo "Running elm with sysconfcpus -n 2"' '$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-old "$@"' > $(npm config get prefix)/bin/elm
+  - chmod +x $(npm config get prefix)/bin/elm
 
 script:
   - elm-test

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,9 +23,6 @@ before_install:
 
 install:
   - npm install -g elm@0.19.0 elm-test@0.19.0-beta9 elm-format@0.8.0
-  - mv $(npm config get prefix)/bin/elm $(npm config get prefix)/bin/elm-old
-  - printf '%s\n\n' '#!/bin/bash' 'echo "Running elm with sysconfcpus -n 2"' '$TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-old "$@"' > $(npm config get prefix)/bin/elm
-  - chmod +x $(npm config get prefix)/bin/elm
 
 script:
-  - elm-test
+  - $TRAVIS_BUILD_DIR/sysconfcpus/bin/sysconfcpus -n 2 elm-test

--- a/src/DateFormat.elm
+++ b/src/DateFormat.elm
@@ -1,44 +1,20 @@
-module DateFormat
-    exposing
-        ( Token
-        , amPmLowercase
-        , amPmUppercase
-        , dayOfMonthFixed
-        , dayOfMonthNumber
-        , dayOfMonthSuffix
-        , dayOfWeekNameAbbreviated
-        , dayOfWeekNameFull
-        , dayOfWeekNumber
-        , dayOfWeekSuffix
-        , dayOfYearFixed
-        , dayOfYearNumber
-        , dayOfYearSuffix
-        , format
-        , formatWithLanguage
-        , hourFixed
-        , hourMilitaryFixed
-        , hourMilitaryFromOneFixed
-        , hourMilitaryFromOneNumber
-        , hourMilitaryNumber
-        , hourNumber
-        , minuteFixed
-        , minuteNumber
-        , monthFixed
-        , monthNameAbbreviated
-        , monthNameFull
-        , monthNumber
-        , monthSuffix
-        , quarterNumber
-        , quarterSuffix
-        , secondFixed
-        , secondNumber
-        , text
-        , weekOfYearFixed
-        , weekOfYearNumber
-        , weekOfYearSuffix
-        , yearNumber
-        , yearNumberLastTwo
-        )
+module DateFormat exposing
+    ( format
+    , formatWithLanguage
+    , Token
+    , monthNumber, monthSuffix, monthFixed, monthNameAbbreviated, monthNameFull
+    , dayOfMonthNumber, dayOfMonthSuffix, dayOfMonthFixed
+    , dayOfYearNumber, dayOfYearSuffix, dayOfYearFixed
+    , dayOfWeekNumber, dayOfWeekSuffix, dayOfWeekNameAbbreviated, dayOfWeekNameFull
+    , yearNumberLastTwo, yearNumber
+    , quarterNumber, quarterSuffix
+    , weekOfYearNumber, weekOfYearSuffix, weekOfYearFixed
+    , amPmUppercase, amPmLowercase
+    , hourMilitaryNumber, hourMilitaryFixed, hourNumber, hourFixed, hourMilitaryFromOneNumber, hourMilitaryFromOneFixed
+    , minuteNumber, minuteFixed
+    , secondNumber, secondFixed
+    , text
+    )
 
 {-| A reliable way to format dates and times with Elm.
 
@@ -60,7 +36,7 @@ module DateFormat
 
 ## Month
 
-@docs monthNumber, monthSuffix, monthFixed, monthNameFirstThree, monthNameFull
+@docs monthNumber, monthSuffix, monthFixed, monthNameAbbreviated, monthNameFull
 
 
 ## Day of the Month
@@ -75,7 +51,7 @@ module DateFormat
 
 ## Day of the Week
 
-@docs dayOfWeekNumber, dayOfWeekSuffix, dayOfWeekNameFirstTwo, dayOfWeekNameFirstThree, dayOfWeekNameFull
+@docs dayOfWeekNumber, dayOfWeekSuffix, dayOfWeekNameAbbreviated, dayOfWeekNameFull
 
 
 ## Year
@@ -159,7 +135,8 @@ monthFixed =
     MonthFixed
 
 
-{-| Get the name of the month, but just the first three letters.
+{-| Get the name of the month, but abbreviated (abbreviation function comes from the language
+settings)
 
 Examples: `Jan, Feb, Mar, ... Nov, Dec`
 
@@ -540,6 +517,7 @@ Let's say `ourPosixValue` is November 15, 1993 at 15:06.
         utc
         ourPosixValue
 
+
     -- "3:06 pm"
     format
         [ hourNumber
@@ -550,6 +528,7 @@ Let's say `ourPosixValue` is November 15, 1993 at 15:06.
         ]
         utc
         ourPosixValue
+
 
     -- "Nov 15th, 1993"
     format
@@ -680,10 +659,10 @@ piece language zone posix token =
                 |> (\num -> String.fromInt num ++ language.toOrdinalSuffix num)
 
         DayOfWeekNameAbbreviated ->
-            language.toWeekdayName (Time.toWeekday zone posix)
+            language.toWeekdayAbbreviation (Time.toWeekday zone posix)
 
         DayOfWeekNameFull ->
-            language.toWeekdayAbbreviation (Time.toWeekday zone posix)
+            language.toWeekdayName (Time.toWeekday zone posix)
 
         WeekOfYearNumber ->
             weekOfYear zone posix
@@ -789,6 +768,7 @@ daysInMonth year_ month =
         Feb ->
             if isLeapYear year_ then
                 29
+
             else
                 28
 
@@ -827,10 +807,13 @@ isLeapYear : Int -> Bool
 isLeapYear year_ =
     if modBy 4 year_ /= 0 then
         False
+
     else if modBy 100 year_ /= 0 then
         True
+
     else if modBy 400 year_ /= 0 then
         False
+
     else
         True
 
@@ -870,7 +853,7 @@ dayOfYear zone posix =
                 |> List.map (daysInMonth (Time.toYear zone posix))
                 |> List.sum
     in
-        daysBeforeThisMonth + dayOfMonth zone posix
+    daysBeforeThisMonth + dayOfMonth zone posix
 
 
 
@@ -913,7 +896,7 @@ weekOfYear zone posix =
         firstDayOffset =
             dayOfWeek zone firstDay
     in
-        (daysSoFar + firstDayOffset) // 7 + 1
+    (daysSoFar + firstDayOffset) // 7 + 1
 
 
 millisecondsPerYear : Int
@@ -957,8 +940,10 @@ toNonMilitary : Int -> Int
 toNonMilitary num =
     if num == 0 then
         12
+
     else if num <= 12 then
         num
+
     else
         num - 12
 
@@ -981,4 +966,4 @@ toFixedLength totalChars num =
                 |> List.map (\_ -> "0")
                 |> String.join ""
     in
-        zeros ++ numStr
+    zeros ++ numStr

--- a/src/DateFormat/Relative.elm
+++ b/src/DateFormat/Relative.elm
@@ -1,10 +1,4 @@
-module DateFormat.Relative
-    exposing
-        ( RelativeTimeOptions
-        , relativeTime
-        , relativeTimeWithOptions
-        , defaultRelativeOptions
-        )
+module DateFormat.Relative exposing (relativeTime, relativeTimeWithOptions, RelativeTimeOptions, defaultRelativeOptions)
 
 {-| A reliable way to get a pretty message for the relative time difference between two dates.
 
@@ -22,17 +16,21 @@ import Time exposing (Month(..), Posix, Weekday(..), Zone, utc)
 
 Here are a few examples to help:
 
-    relativeTime now tenSecondsAgo ==  "just now"
-    relativeTime now tenSecondsFromNow ==  "in a few seconds"
+    relativeTime now tenSecondsAgo == "just now"
+
+    relativeTime now tenSecondsFromNow == "in a few seconds"
 
     relativeTime now fortyThreeMinutesAgo == "43 minutes ago"
 
     relativeTime now oneHundredDaysAgo == "100 days ago"
+
     relativeTime now oneHundredDaysFromNow == "in 100 days"
 
+
     -- Order matters!
-    relativeTime now tenSecondsAgo ==  "just now"
-    relativeTime tenSecondsAgo now ==  "in a few seconds"
+    relativeTime now tenSecondsAgo == "just now"
+
+    relativeTime tenSecondsAgo now == "in a few seconds"
 
 -}
 relativeTime : Posix -> Posix -> String
@@ -55,31 +53,29 @@ relativeTimeWithOptions options start end =
         differenceInMilliseconds : Int
         differenceInMilliseconds =
             toMilliseconds end - toMilliseconds start
-
-        time : Posix
-        time =
-            Time.millisToPosix (abs differenceInMilliseconds)
     in
-        if differenceInMilliseconds == 0 then
-            options.rightNow
-        else
-            relativeTimeWithFunctions utc time <|
-                if differenceInMilliseconds < 0 then
-                    RelativeTimeFunctions
-                        options.someSecondsAgo
-                        options.someMinutesAgo
-                        options.someHoursAgo
-                        options.someDaysAgo
-                        options.someMonthsAgo
-                        options.someYearsAgo
-                else
-                    RelativeTimeFunctions
-                        options.inSomeSeconds
-                        options.inSomeMinutes
-                        options.inSomeHours
-                        options.inSomeDays
-                        options.inSomeMonths
-                        options.inSomeYears
+    if differenceInMilliseconds == 0 then
+        options.rightNow
+
+    else
+        relativeTimeWithFunctions utc (abs differenceInMilliseconds) <|
+            if differenceInMilliseconds < 0 then
+                RelativeTimeFunctions
+                    options.someSecondsAgo
+                    options.someMinutesAgo
+                    options.someHoursAgo
+                    options.someDaysAgo
+                    options.someMonthsAgo
+                    options.someYearsAgo
+
+            else
+                RelativeTimeFunctions
+                    options.inSomeSeconds
+                    options.inSomeMinutes
+                    options.inSomeHours
+                    options.inSomeDays
+                    options.inSomeMonths
+                    options.inSomeYears
 
 
 {-| Options for configuring your own relative message formats!
@@ -90,6 +86,7 @@ For example, here is how `someSecondsAgo` is implemented by default:
     defaultSomeSecondsAgo seconds =
         if seconds < 30 then
             "just now"
+
         else
             toString seconds ++ " seconds ago"
 
@@ -99,6 +96,7 @@ And here is how `inSomeHours` might look:
     defaultInSomeHours hours =
         if hours < 2 then
             "in an hour"
+
         else
             "in " ++ toString hours ++ " hours"
 
@@ -155,20 +153,41 @@ type alias RelativeTimeFunctions =
     }
 
 
-relativeTimeWithFunctions : Zone -> Posix -> RelativeTimeFunctions -> String
-relativeTimeWithFunctions zone posix functions =
-    if Time.toMinute zone posix < 1 then
+relativeTimeWithFunctions : Zone -> Int -> RelativeTimeFunctions -> String
+relativeTimeWithFunctions zone millis functions =
+    let
+        posix =
+            Time.millisToPosix millis
+
+        seconds =
+            millis // 1000
+
+        minutes =
+            seconds // 60
+
+        hours =
+            minutes // 60
+
+        days =
+            hours // 24
+    in
+    if minutes < 1 then
         functions.seconds <| Time.toSecond zone posix
-    else if Time.toHour zone posix < 1 then
+
+    else if hours < 1 then
         functions.minutes <| Time.toMinute zone posix
-    else if Time.toHour zone posix < 24 then
+
+    else if hours < 24 then
         functions.hours <| Time.toHour zone posix
-    else if Time.toHour zone posix < 24 * 30 then
-        functions.days <| (Time.toHour zone posix // 24)
-    else if Time.toHour zone posix < 24 * 365 then
-        functions.months <| (Time.toHour zone posix // 24 // 12)
+
+    else if days < 30 then
+        functions.days <| days
+
+    else if days < 365 then
+        functions.months <| (days // 12)
+
     else
-        functions.years <| (Time.toHour zone posix // 24 // 365)
+        functions.years <| (days // 365)
 
 
 defaultRightNow : String
@@ -180,6 +199,7 @@ defaultSomeSecondsAgo : Int -> String
 defaultSomeSecondsAgo seconds =
     if seconds < 30 then
         "just now"
+
     else
         String.fromInt seconds ++ " seconds ago"
 
@@ -188,6 +208,7 @@ defaultSomeMinutesAgo : Int -> String
 defaultSomeMinutesAgo minutes =
     if minutes < 2 then
         "a minute ago"
+
     else
         String.fromInt minutes ++ " minutes ago"
 
@@ -196,6 +217,7 @@ defaultSomeHoursAgo : Int -> String
 defaultSomeHoursAgo hours =
     if hours < 2 then
         "an hour ago"
+
     else
         String.fromInt hours ++ " hours ago"
 
@@ -204,6 +226,7 @@ defaultSomeDaysAgo : Int -> String
 defaultSomeDaysAgo days =
     if days < 2 then
         "yesterday"
+
     else
         String.fromInt days ++ " days ago"
 
@@ -212,6 +235,7 @@ defaultSomeMonthsAgo : Int -> String
 defaultSomeMonthsAgo months =
     if months < 2 then
         "last month"
+
     else
         String.fromInt months ++ " months ago"
 
@@ -220,6 +244,7 @@ defaultSomeYearsAgo : Int -> String
 defaultSomeYearsAgo years =
     if years < 2 then
         "last year"
+
     else
         String.fromInt years ++ " years ago"
 
@@ -228,6 +253,7 @@ defaultInSomeSeconds : Int -> String
 defaultInSomeSeconds seconds =
     if seconds < 30 then
         "in a few seconds"
+
     else
         "in " ++ String.fromInt seconds ++ " seconds"
 
@@ -236,6 +262,7 @@ defaultInSomeMinutes : Int -> String
 defaultInSomeMinutes minutes =
     if minutes < 2 then
         "in a minute"
+
     else
         "in " ++ String.fromInt minutes ++ " minutes"
 
@@ -244,6 +271,7 @@ defaultInSomeHours : Int -> String
 defaultInSomeHours hours =
     if hours < 2 then
         "in an hour"
+
     else
         "in " ++ String.fromInt hours ++ " hours"
 
@@ -252,6 +280,7 @@ defaultInSomeDays : Int -> String
 defaultInSomeDays days =
     if days < 2 then
         "tomorrow"
+
     else
         "in " ++ String.fromInt days ++ " days"
 
@@ -260,6 +289,7 @@ defaultInSomeMonths : Int -> String
 defaultInSomeMonths months =
     if months < 2 then
         "in a month"
+
     else
         "in " ++ String.fromInt months ++ " months"
 
@@ -268,5 +298,6 @@ defaultInSomeYears : Int -> String
 defaultInSomeYears years =
     if years < 2 then
         "in a year"
+
     else
         "in " ++ String.fromInt years ++ " years"

--- a/tests/RelativeTests.elm
+++ b/tests/RelativeTests.elm
@@ -1,0 +1,103 @@
+module RelativeTests exposing (suite)
+
+import DateFormat.Relative exposing (relativeTime)
+import Expect exposing (Expectation)
+import Fuzz
+import Test exposing (..)
+import Time exposing (Posix, utc)
+
+
+time =
+    Time.millisToPosix 1537190428785
+
+
+applyDiff diff =
+    Time.millisToPosix <| Time.posixToMillis time + diff
+
+
+addSeconds secs =
+    applyDiff (secs * 1000)
+
+
+addMins mins =
+    addSeconds (mins * 60)
+
+
+addHours hours =
+    addMins (hours * 60)
+
+
+addDays days =
+    addHours (days * 24)
+
+
+suite : Test
+suite =
+    describe "The DateFormat.Relative module"
+        [ test "right now" <|
+            \_ -> relativeTime time time |> Expect.equal "right now"
+        , fuzz (Fuzz.intRange -29 -1) "last 30s" <|
+            \secs ->
+                relativeTime time (addSeconds secs)
+                    |> Expect.equal "just now"
+        , fuzz (Fuzz.intRange -59 -30) "30-59s ago" <|
+            \secs ->
+                relativeTime time (addSeconds secs)
+                    |> Expect.equal (String.fromInt (abs secs) ++ " seconds ago")
+        , test "1 min" <|
+            \_ ->
+                relativeTime time (addMins -1)
+                    |> Expect.equal "a minute ago"
+        , fuzz (Fuzz.intRange -59 -2) "2-59 mins ago" <|
+            \mins ->
+                relativeTime time (addMins mins)
+                    |> Expect.equal (String.fromInt (abs mins) ++ " minutes ago")
+        , test "1 hour" <|
+            \_ ->
+                relativeTime time (addHours -1)
+                    |> Expect.equal "an hour ago"
+        , fuzz (Fuzz.intRange -23 -2) "2-23 hours ago" <|
+            \hours ->
+                relativeTime time (addHours hours)
+                    |> Expect.equal (String.fromInt (abs hours) ++ " hours ago")
+        , test "yesterday" <|
+            \_ ->
+                relativeTime time (addDays -1)
+                    |> Expect.equal "yesterday"
+        , fuzz (Fuzz.intRange -27 -2) "2-27 days ago" <|
+            \days ->
+                relativeTime time (addDays days)
+                    |> Expect.equal (String.fromInt (abs days) ++ " days ago")
+        , fuzz (Fuzz.intRange 1 29) "next 29s" <|
+            \secs ->
+                relativeTime time (addSeconds secs)
+                    |> Expect.equal "in a few seconds"
+        , fuzz (Fuzz.intRange 31 59) "31-59s from now" <|
+            \secs ->
+                relativeTime time (addSeconds secs)
+                    |> Expect.equal ("in " ++ String.fromInt (abs secs) ++ " seconds")
+        , test "1 min future" <|
+            \_ ->
+                relativeTime time (addMins 1)
+                    |> Expect.equal "in a minute"
+        , fuzz (Fuzz.intRange 2 59) "2-59 mins from now" <|
+            \mins ->
+                relativeTime time (addMins mins)
+                    |> Expect.equal ("in " ++ String.fromInt (abs mins) ++ " minutes")
+        , test "in 1 hour" <|
+            \_ ->
+                relativeTime time (addHours 1)
+                    |> Expect.equal "in an hour"
+        , fuzz (Fuzz.intRange 2 23) "2-23 hours from now" <|
+            \hours ->
+                relativeTime time (addHours hours)
+                    |> Expect.equal ("in " ++ String.fromInt (abs hours) ++ " hours")
+        , test "tomorrow" <|
+            \_ ->
+                relativeTime time (addDays 1)
+                    |> Expect.equal "tomorrow"
+        , fuzz (Fuzz.intRange 2 27) "2-27 days from now" <|
+            \days ->
+                relativeTime time (addDays days)
+                    |> Expect.equal ("in " ++ String.fromInt (abs days) ++ " days")
+        ]

--- a/tests/Tests.elm
+++ b/tests/Tests.elm
@@ -111,17 +111,17 @@ suite =
             [ fuzz Fuzzers.datetime "Is between 1 and 12" <|
                 fixedWithinRange 2 1 12 DateFormat.monthFixed
             ]
-        , describe "monthNameFirstThree"
+        , describe "monthNameAbbreviated"
             [ fuzz Fuzzers.datetime "Is always three characters long" <|
-                formatsWithLength 3 DateFormat.monthNameFirstThree
+                formatsWithLength 3 DateFormat.monthNameAbbreviated
             ]
         , describe "monthNameFull"
-            [ fuzz Fuzzers.datetime "Starts with first three" <|
+            [ fuzz Fuzzers.datetime "Starts with abbreviation" <|
                 \date ->
                     let
-                        firstThree =
+                        abbrev =
                             DateFormat.format
-                                [ DateFormat.monthNameFirstThree ]
+                                [ DateFormat.monthNameAbbreviated ]
                                 utc
                                 date
 
@@ -132,7 +132,7 @@ suite =
                                 date
                     in
                     Expect.equal
-                        firstThree
+                        abbrev
                         (String.left 3 fullName)
             , fuzz Fuzzers.datetime "Is a valid month" <|
                 \date ->
@@ -197,21 +197,17 @@ suite =
             [ fuzz Fuzzers.datetime "Is between 0 and 6" <|
                 suffixWithinRange 0 6 DateFormat.dayOfWeekSuffix
             ]
-        , describe "dayOfWeekNameFirstTwo"
-            [ fuzz Fuzzers.datetime "Is always two characters long" <|
-                formatsWithLength 2 DateFormat.dayOfWeekNameFirstTwo
-            ]
-        , describe "dayOfWeekNameFirstThree"
+        , describe "dayOfWeekNameAbbreviated"
             [ fuzz Fuzzers.datetime "Is always three characters long" <|
-                formatsWithLength 3 DateFormat.dayOfWeekNameFirstThree
+                formatsWithLength 3 DateFormat.dayOfWeekNameAbbreviated
             ]
         , describe "dayOfWeekNameFull"
-            [ fuzz Fuzzers.datetime "Starts with first two" <|
+            [ fuzz Fuzzers.datetime "Starts with abbreviation" <|
                 \date ->
                     let
-                        firstTwo =
+                        abbrev =
                             DateFormat.format
-                                [ DateFormat.dayOfWeekNameFirstTwo ]
+                                [ DateFormat.dayOfWeekNameAbbreviated ]
                                 utc
                                 date
 
@@ -222,25 +218,7 @@ suite =
                                 date
                     in
                     Expect.equal
-                        firstTwo
-                        (String.left 2 fullName)
-            , fuzz Fuzzers.datetime "Starts with first three" <|
-                \date ->
-                    let
-                        firstThree =
-                            DateFormat.format
-                                [ DateFormat.dayOfWeekNameFirstThree ]
-                                utc
-                                date
-
-                        fullName =
-                            DateFormat.format
-                                [ DateFormat.dayOfWeekNameFull ]
-                                utc
-                                date
-                    in
-                    Expect.equal
-                        firstThree
+                        abbrev
                         (String.left 3 fullName)
             , fuzz Fuzzers.datetime "Is a valid month" <|
                 \date ->


### PR DESCRIPTION
The RelativeTime wasn't working, because `Time.toHour` etc. all return
"clock-face" times, i.e. "hours since midnight" or "minutes since the
last hour". For relative time calculations this is really unhelpful; it
meant that relativeTime would often return the wrong value, e.g. "just
now" for any diff that was too close to an exact multiple of an hour.