### PR TITLE
Fix relative months calculation

### DIFF
--- a/elm.json
+++ b/elm.json
@@ -3,7 +3,7 @@
     "name": "ryannhg/date-format",
     "summary": "A reliable way to format dates and times with Elm.",
     "license": "BSD-3-Clause",
-    "version": "2.2.0",
+    "version": "2.2.1",
     "exposed-modules": [
         "DateFormat",
         "DateFormat.Language",

--- a/src/DateFormat/Relative.elm
+++ b/src/DateFormat/Relative.elm
@@ -184,7 +184,7 @@ relativeTimeWithFunctions zone millis functions =
         functions.days <| days
 
     else if days < 365 then
-        functions.months <| (days // 12)
+        functions.months <| (days // 30)
 
     else
         functions.years <| (days // 365)

--- a/tests/RelativeTests.elm
+++ b/tests/RelativeTests.elm
@@ -31,6 +31,10 @@ addDays days =
     addHours (days * 24)
 
 
+addMonths months =
+    addDays (months * 30)
+
+
 suite : Test
 suite =
     describe "The DateFormat.Relative module"
@@ -68,6 +72,26 @@ suite =
             \days ->
                 relativeTime time (addDays days)
                     |> Expect.equal (String.fromInt (abs days) ++ " days ago")
+        , fuzz (Fuzz.intRange -11 -2) "2-11 months ago" <|
+            \days ->
+                relativeTime time (addMonths days)
+                    |> Expect.equal (String.fromInt (abs days) ++ " months ago")
+        , test "12 months ago" <|
+            \_ ->
+                relativeTime time (addMonths -12)
+                    |> Expect.equal "12 months ago"
+        , test "last year" <|
+            \_ ->
+                relativeTime time (addMonths -13)
+                    |> Expect.equal "last year"
+        , test "last year 2" <|
+            \_ ->
+                relativeTime time (addMonths -23)
+                    |> Expect.equal "last year"
+        , test "2 years ago" <|
+            \_ ->
+                relativeTime time (addMonths -25)
+                    |> Expect.equal "2 years ago"
         , fuzz (Fuzz.intRange 1 29) "next 29s" <|
             \secs ->
                 relativeTime time (addSeconds secs)
@@ -100,4 +124,24 @@ suite =
             \days ->
                 relativeTime time (addDays days)
                     |> Expect.equal ("in " ++ String.fromInt (abs days) ++ " days")
+        , fuzz (Fuzz.intRange 2 11) "in 2-11 months" <|
+            \days ->
+                relativeTime time (addMonths days)
+                    |> Expect.equal ("in " ++ String.fromInt (abs days) ++ " months")
+        , test "in 12 months" <|
+            \_ ->
+                relativeTime time (addMonths 12)
+                    |> Expect.equal "in 12 months"
+        , test "in a year" <|
+            \_ ->
+                relativeTime time (addMonths 13)
+                    |> Expect.equal "in a year"
+        , test "in a year 2" <|
+            \_ ->
+                relativeTime time (addMonths 23)
+                    |> Expect.equal "in a year"
+        , test "in 2 years" <|
+            \_ ->
+                relativeTime time (addMonths 25)
+                    |> Expect.equal "in 2 years"
         ]


### PR DESCRIPTION
Hi! The calculation for the relative time regarding months is wrong: 

https://github.com/ryannhg/date-format/blob/master/src/DateFormat/Relative.elm#L187

There was no test for relative time regarding both months and years, so I added them.

PS: I'm using this in https://revisar.me and ~I'll try to contribute a Portuguese language pack after this~ Done: https://github.com/ryannhg/date-format/pull/16