### PR TITLE
Replace monthNameFirstThree(deprecated) by monthNameAbbreviated

### DIFF
--- a/src/DateFormat.elm
+++ b/src/DateFormat.elm
@@ -545,7 +545,6 @@ Let's say `ourPosixValue` is November 15, 1993 at 15:06.
         utc
         ourPosixValue
 
-
     -- "3:06 pm"
     format
         [ hourNumber
@@ -557,10 +556,9 @@ Let's say `ourPosixValue` is November 15, 1993 at 15:06.
         utc
         ourPosixValue
 
-
     -- "Nov 15th, 1993"
     format
-        [ monthNameFirstThree
+        [ monthNameAbbreviated
         , text " "
         , dayOfMonthSuffix
         , text ", "


### PR DESCRIPTION
monthNameFirstThree has been removed from the API, but there was this single place in the docs using it when it should use the monthNameAbbreviated.
