### PR TITLE
Relative times with languages support

### DIFF
--- a/src/DateFormat/Language.elm
+++ b/src/DateFormat/Language.elm
@@ -1,6 +1,7 @@
 module DateFormat.Language exposing
     ( Language
     , english, spanish, dutch, swedish, portuguese
+    , finnish
     )
 
 {-|
@@ -494,3 +495,98 @@ toPortugueseWeekdayName weekday =
 
         Sun ->
             "Domingo"
+
+
+
+-- Finnish
+
+
+toFinnishMonthName : Month -> String
+toFinnishMonthName month =
+    case month of
+        Jan ->
+            "tammikuu"
+
+        Feb ->
+            "helmikuu"
+
+        Mar ->
+            "maaliskuu"
+
+        Apr ->
+            "huhtikuu"
+
+        May ->
+            "toukokuu"
+
+        Jun ->
+            "kesäkuu"
+
+        Jul ->
+            "heinäkuu"
+
+        Aug ->
+            "elokuu"
+
+        Sep ->
+            "syyskuu"
+
+        Oct ->
+            "lokakuu"
+
+        Nov ->
+            "marraskuu"
+
+        Dec ->
+            "joulukuu"
+
+
+toFinnishWeekdayName : Weekday -> String
+toFinnishWeekdayName weekday =
+    case weekday of
+        Mon ->
+            "maanantai"
+
+        Tue ->
+            "tiistai"
+
+        Wed ->
+            "keskiviikko"
+
+        Thu ->
+            "torstai"
+
+        Fri ->
+            "perjantai"
+
+        Sat ->
+            "lauantai"
+
+        Sun ->
+            "sunnuntai"
+
+
+{-| Only 24h formats are used in the Finnish language. AM/PM do technically have translations,
+but using them would go against the [guidelines](http://www.kielitoimistonohjepankki.fi/ohje/51).
+-}
+toFinnishAmPm : Int -> String
+toFinnishAmPm _ =
+    ""
+
+
+toFinnishSuffix : Int -> String
+toFinnishSuffix _ =
+    "."
+
+
+{-| The Finnish language!
+-}
+finnish : Language
+finnish =
+    Language
+        toFinnishMonthName
+        (toFinnishMonthName >> String.replace "kuu" "")
+        toFinnishWeekdayName
+        (toFinnishWeekdayName >> String.left 2)
+        toFinnishAmPm
+        toFinnishSuffix

--- a/src/DateFormat/Language.elm
+++ b/src/DateFormat/Language.elm
@@ -1,7 +1,6 @@
 module DateFormat.Language exposing
     ( Language
-    , english, spanish, dutch, swedish, portuguese
-    , finnish
+    , english, spanish, dutch, swedish, portuguese, finnish
     )
 
 {-|
@@ -23,7 +22,7 @@ This module exposes `Language`, along with a few implementations.
 
 ### Languages
 
-@docs english, spanish, dutch, swedish, portuguese
+@docs english, spanish, dutch, swedish, portuguese, finnish
 
 -}
 

--- a/src/DateFormat/Relative.elm
+++ b/src/DateFormat/Relative.elm
@@ -1,14 +1,15 @@
-module DateFormat.Relative exposing (relativeTime, relativeTimeWithOptions, RelativeTimeOptions, defaultRelativeOptions)
+module DateFormat.Relative exposing (relativeTime, relativeTimeWithOptions)
 
 {-| A reliable way to get a pretty message for the relative time difference between two dates.
 
 
 # Getting relative time for two dates
 
-@docs relativeTime, relativeTimeWithOptions, RelativeTimeOptions, defaultRelativeOptions
+@docs relativeTime, relativeTimeWithOptions
 
 -}
 
+import DateFormat.Relative.Language exposing (RelativeTimeOptions)
 import Time exposing (Month(..), Posix, Weekday(..), Zone, utc)
 
 
@@ -26,7 +27,6 @@ Here are a few examples to help:
 
     relativeTime now oneHundredDaysFromNow == "in 100 days"
 
-
     -- Order matters!
     relativeTime now tenSecondsAgo == "just now"
 
@@ -35,14 +35,15 @@ Here are a few examples to help:
 -}
 relativeTime : Posix -> Posix -> String
 relativeTime =
-    relativeTimeWithOptions defaultRelativeOptions
+    relativeTimeWithOptions DateFormat.Relative.Language.english
 
 
 {-| Maybe `relativeTime` is too lame. (Or maybe you speak a different language than English!)
 
-With `relativeTimeWithOptions`, you can provide your own custom messages for each time range.
+With `relativeTimeWithOptions`, you can use one of the predefined options in
+`DateFormat.Relative.Language` or even provide your own custom messages for each time range.
 
-(That's what `relativeTime` uses under the hood!)
+That's what `relativeTime` does: it uses the `english` options under the hood!
 
 You can provide a set of your own custom options, and use `relativeTimeWithOptions` instead.
 
@@ -76,66 +77,6 @@ relativeTimeWithOptions options start end =
                     options.inSomeDays
                     options.inSomeMonths
                     options.inSomeYears
-
-
-{-| Options for configuring your own relative message formats!
-
-For example, here is how `someSecondsAgo` is implemented by default:
-
-    defaultSomeSecondsAgo : Int -> String
-    defaultSomeSecondsAgo seconds =
-        if seconds < 30 then
-            "just now"
-
-        else
-            toString seconds ++ " seconds ago"
-
-And here is how `inSomeHours` might look:
-
-    defaultInSomeHours : Int -> String
-    defaultInSomeHours hours =
-        if hours < 2 then
-            "in an hour"
-
-        else
-            "in " ++ toString hours ++ " hours"
-
--}
-type alias RelativeTimeOptions =
-    { someSecondsAgo : Int -> String
-    , someMinutesAgo : Int -> String
-    , someHoursAgo : Int -> String
-    , someDaysAgo : Int -> String
-    , someMonthsAgo : Int -> String
-    , someYearsAgo : Int -> String
-    , rightNow : String
-    , inSomeSeconds : Int -> String
-    , inSomeMinutes : Int -> String
-    , inSomeHours : Int -> String
-    , inSomeDays : Int -> String
-    , inSomeMonths : Int -> String
-    , inSomeYears : Int -> String
-    }
-
-
-{-| If there is something you'd like to tweak based off of the defaults, this record might be a good starting point!
--}
-defaultRelativeOptions : RelativeTimeOptions
-defaultRelativeOptions =
-    { someSecondsAgo = defaultSomeSecondsAgo
-    , someMinutesAgo = defaultSomeMinutesAgo
-    , someHoursAgo = defaultSomeHoursAgo
-    , someDaysAgo = defaultSomeDaysAgo
-    , someMonthsAgo = defaultSomeMonthsAgo
-    , someYearsAgo = defaultSomeYearsAgo
-    , rightNow = defaultRightNow
-    , inSomeSeconds = defaultInSomeSeconds
-    , inSomeMinutes = defaultInSomeMinutes
-    , inSomeHours = defaultInSomeHours
-    , inSomeDays = defaultInSomeDays
-    , inSomeMonths = defaultInSomeMonths
-    , inSomeYears = defaultInSomeYears
-    }
 
 
 toMilliseconds : Posix -> Int
@@ -188,116 +129,3 @@ relativeTimeWithFunctions zone millis functions =
 
     else
         functions.years <| (days // 365)
-
-
-defaultRightNow : String
-defaultRightNow =
-    "right now"
-
-
-defaultSomeSecondsAgo : Int -> String
-defaultSomeSecondsAgo seconds =
-    if seconds < 30 then
-        "just now"
-
-    else
-        String.fromInt seconds ++ " seconds ago"
-
-
-defaultSomeMinutesAgo : Int -> String
-defaultSomeMinutesAgo minutes =
-    if minutes < 2 then
-        "a minute ago"
-
-    else
-        String.fromInt minutes ++ " minutes ago"
-
-
-defaultSomeHoursAgo : Int -> String
-defaultSomeHoursAgo hours =
-    if hours < 2 then
-        "an hour ago"
-
-    else
-        String.fromInt hours ++ " hours ago"
-
-
-defaultSomeDaysAgo : Int -> String
-defaultSomeDaysAgo days =
-    if days < 2 then
-        "yesterday"
-
-    else
-        String.fromInt days ++ " days ago"
-
-
-defaultSomeMonthsAgo : Int -> String
-defaultSomeMonthsAgo months =
-    if months < 2 then
-        "last month"
-
-    else
-        String.fromInt months ++ " months ago"
-
-
-defaultSomeYearsAgo : Int -> String
-defaultSomeYearsAgo years =
-    if years < 2 then
-        "last year"
-
-    else
-        String.fromInt years ++ " years ago"
-
-
-defaultInSomeSeconds : Int -> String
-defaultInSomeSeconds seconds =
-    if seconds < 30 then
-        "in a few seconds"
-
-    else
-        "in " ++ String.fromInt seconds ++ " seconds"
-
-
-defaultInSomeMinutes : Int -> String
-defaultInSomeMinutes minutes =
-    if minutes < 2 then
-        "in a minute"
-
-    else
-        "in " ++ String.fromInt minutes ++ " minutes"
-
-
-defaultInSomeHours : Int -> String
-defaultInSomeHours hours =
-    if hours < 2 then
-        "in an hour"
-
-    else
-        "in " ++ String.fromInt hours ++ " hours"
-
-
-defaultInSomeDays : Int -> String
-defaultInSomeDays days =
-    if days < 2 then
-        "tomorrow"
-
-    else
-        "in " ++ String.fromInt days ++ " days"
-
-
-defaultInSomeMonths : Int -> String
-defaultInSomeMonths months =
-    if months < 2 then
-        "in a month"
-
-    else
-        "in " ++ String.fromInt months ++ " months"
-
-
-defaultInSomeYears : Int -> String
-defaultInSomeYears years =
-    if years < 2 then
-        "in a year"
-
-    else
-        "in " ++ String.fromInt years ++ " years"

--- a/src/DateFormat/Relative/Language.elm
+++ b/src/DateFormat/Relative/Language.elm
@@ -1,0 +1,349 @@
+module DateFormat.Relative.Language exposing
+    ( RelativeTimeOptions
+    , english, finnish
+    )
+
+{-|
+
+
+## Fun fact: Some people don't know english.
+
+That's why it's important to include alternative date formatting options for other languages!
+
+This module exposes implementations of `RelativeTimeOptions`, for different languages.
+
+(If you want to see `french`, `german`, or `greek`, please add them in! I'm happy to make your language a part of the package!)
+
+
+### Options
+
+@docs RelativeTimeOptions
+
+
+### Languages
+
+@docs english, finnish
+
+-}
+
+
+{-| Options for configuring your own relative message formats!
+
+For example, here is how `someSecondsAgo` is implemented for English:
+
+    englishSomeSecondsAgo : Int -> String
+    englishSomeSecondsAgo seconds =
+        if seconds < 30 then
+            "just now"
+
+        else
+            toString seconds ++ " seconds ago"
+
+And here is how `inSomeHours` might look:
+
+    englishInSomeHours : Int -> String
+    englishInSomeHours hours =
+        if hours < 2 then
+            "in an hour"
+
+        else
+            "in " ++ toString hours ++ " hours"
+
+-}
+type alias RelativeTimeOptions =
+    { someSecondsAgo : Int -> String
+    , someMinutesAgo : Int -> String
+    , someHoursAgo : Int -> String
+    , someDaysAgo : Int -> String
+    , someMonthsAgo : Int -> String
+    , someYearsAgo : Int -> String
+    , rightNow : String
+    , inSomeSeconds : Int -> String
+    , inSomeMinutes : Int -> String
+    , inSomeHours : Int -> String
+    , inSomeDays : Int -> String
+    , inSomeMonths : Int -> String
+    , inSomeYears : Int -> String
+    }
+
+
+
+-- English
+
+
+{-| English language options (the default)
+-}
+english : RelativeTimeOptions
+english =
+    { someSecondsAgo = englishSomeSecondsAgo
+    , someMinutesAgo = englishSomeMinutesAgo
+    , someHoursAgo = englishSomeHoursAgo
+    , someDaysAgo = englishSomeDaysAgo
+    , someMonthsAgo = englishSomeMonthsAgo
+    , someYearsAgo = englishSomeYearsAgo
+    , rightNow = englishRightNow
+    , inSomeSeconds = englishInSomeSeconds
+    , inSomeMinutes = englishInSomeMinutes
+    , inSomeHours = englishInSomeHours
+    , inSomeDays = englishInSomeDays
+    , inSomeMonths = englishInSomeMonths
+    , inSomeYears = englishInSomeYears
+    }
+
+
+englishRightNow : String
+englishRightNow =
+    "right now"
+
+
+englishSomeSecondsAgo : Int -> String
+englishSomeSecondsAgo seconds =
+    if seconds < 30 then
+        "just now"
+
+    else
+        String.fromInt seconds ++ " seconds ago"
+
+
+englishSomeMinutesAgo : Int -> String
+englishSomeMinutesAgo minutes =
+    if minutes < 2 then
+        "a minute ago"
+
+    else
+        String.fromInt minutes ++ " minutes ago"
+
+
+englishSomeHoursAgo : Int -> String
+englishSomeHoursAgo hours =
+    if hours < 2 then
+        "an hour ago"
+
+    else
+        String.fromInt hours ++ " hours ago"
+
+
+englishSomeDaysAgo : Int -> String
+englishSomeDaysAgo days =
+    if days < 2 then
+        "yesterday"
+
+    else
+        String.fromInt days ++ " days ago"
+
+
+englishSomeMonthsAgo : Int -> String
+englishSomeMonthsAgo months =
+    if months < 2 then
+        "last month"
+
+    else
+        String.fromInt months ++ " months ago"
+
+
+englishSomeYearsAgo : Int -> String
+englishSomeYearsAgo years =
+    if years < 2 then
+        "last year"
+
+    else
+        String.fromInt years ++ " years ago"
+
+
+englishInSomeSeconds : Int -> String
+englishInSomeSeconds seconds =
+    if seconds < 30 then
+        "in a few seconds"
+
+    else
+        "in " ++ String.fromInt seconds ++ " seconds"
+
+
+englishInSomeMinutes : Int -> String
+englishInSomeMinutes minutes =
+    if minutes < 2 then
+        "in a minute"
+
+    else
+        "in " ++ String.fromInt minutes ++ " minutes"
+
+
+englishInSomeHours : Int -> String
+englishInSomeHours hours =
+    if hours < 2 then
+        "in an hour"
+
+    else
+        "in " ++ String.fromInt hours ++ " hours"
+
+
+englishInSomeDays : Int -> String
+englishInSomeDays days =
+    if days < 2 then
+        "tomorrow"
+
+    else
+        "in " ++ String.fromInt days ++ " days"
+
+
+englishInSomeMonths : Int -> String
+englishInSomeMonths months =
+    if months < 2 then
+        "in a month"
+
+    else
+        "in " ++ String.fromInt months ++ " months"
+
+
+englishInSomeYears : Int -> String
+englishInSomeYears years =
+    if years < 2 then
+        "in a year"
+
+    else
+        "in " ++ String.fromInt years ++ " years"
+
+
+
+-- Finnish
+
+
+{-| Finnish language options
+-}
+finnish : RelativeTimeOptions
+finnish =
+    { someSecondsAgo = finnishSomeSecondsAgo
+    , someMinutesAgo = finnishSomeMinutesAgo
+    , someHoursAgo = finnishSomeHoursAgo
+    , someDaysAgo = finnishSomeDaysAgo
+    , someMonthsAgo = finnishSomeMonthsAgo
+    , someYearsAgo = finnishSomeYearsAgo
+    , rightNow = finnishRightNow
+    , inSomeSeconds = finnishInSomeSeconds
+    , inSomeMinutes = finnishInSomeMinutes
+    , inSomeHours = finnishInSomeHours
+    , inSomeDays = finnishInSomeDays
+    , inSomeMonths = finnishInSomeMonths
+    , inSomeYears = finnishInSomeYears
+    }
+
+
+finnishRightNow : String
+finnishRightNow =
+    "juuri nyt"
+
+
+finnishSomeSecondsAgo : Int -> String
+finnishSomeSecondsAgo seconds =
+    if seconds < 30 then
+        "juuri äsken"
+
+    else
+        String.fromInt seconds ++ " sekuntia sitten"
+
+
+finnishSomeMinutesAgo : Int -> String
+finnishSomeMinutesAgo minutes =
+    if minutes < 2 then
+        "minuutti sitten"
+
+    else
+        String.fromInt minutes ++ " minuuttia sitten"
+
+
+finnishSomeHoursAgo : Int -> String
+finnishSomeHoursAgo hours =
+    if hours < 2 then
+        "tunti sitten"
+
+    else
+        String.fromInt hours ++ " tuntia sitten"
+
+
+finnishSomeDaysAgo : Int -> String
+finnishSomeDaysAgo days =
+    if days < 2 then
+        "eilen"
+
+    else if days < 2 then
+        "toissapäivänä"
+
+    else
+        String.fromInt days ++ " päivää sitten"
+
+
+finnishSomeMonthsAgo : Int -> String
+finnishSomeMonthsAgo months =
+    if months < 2 then
+        "kuukausi sitten"
+
+    else
+        String.fromInt months ++ " kuukautta sitten"
+
+
+finnishSomeYearsAgo : Int -> String
+finnishSomeYearsAgo years =
+    if years < 2 then
+        "vuosi sitten"
+
+    else
+        String.fromInt years ++ " vuotta sitten"
+
+
+finnishInSomeSeconds : Int -> String
+finnishInSomeSeconds seconds =
+    (if seconds < 30 then
+        "muutaman"
+
+     else
+        String.fromInt seconds
+    )
+        ++ " sekunnin kuluttua"
+
+
+finnishInSomeMinutes : Int -> String
+finnishInSomeMinutes minutes =
+    if minutes < 2 then
+        "minuutin kuluttua"
+
+    else
+        String.fromInt minutes ++ " minuutin kuluttua"
+
+
+finnishInSomeHours : Int -> String
+finnishInSomeHours hours =
+    if hours < 2 then
+        "tunnin kuluttua"
+
+    else
+        String.fromInt hours ++ " tunnin kuluttua"
+
+
+finnishInSomeDays : Int -> String
+finnishInSomeDays days =
+    if days < 2 then
+        "huomenna"
+
+    else if days < 3 then
+        "ylihuomenna"
+
+    else
+        String.fromInt days ++ " päivän kuluttua"
+
+
+finnishInSomeMonths : Int -> String
+finnishInSomeMonths months =
+    if months < 2 then
+        "kuukauden kuluttua"
+
+    else
+        String.fromInt months ++ " kuukauden kuluttua"
+
+
+finnishInSomeYears : Int -> String
+finnishInSomeYears years =
+    if years < 2 then
+        "ensi vuonna"
+
+    else
+        String.fromInt years ++ " vuoden kuluttua"


### PR DESCRIPTION
This is a bit of a daring PR out of the blue, so feel free to disagree with my decisions and/or point out issues I might not have noticed. I introduced a new module: `DateFormat.Relative.Language`. Then I moved the `RelativeTimeOptions` along with the default (now called `english`) to that module. Finally, I localized the relative time options for Finnish.

Because of the type moved from `DateFormat.Relative` to `DateFormat.Relative.Language` (to avoid circular imports), this change would be a major version. If you'd really like to avoid that, there's at least two ways to do it:

1. expose the type through a dummy `type alias MyType = Module.MyType`, which can be confusing for people (which one do they need to import to be able to construct a record?)
2. move the type back to the old place and keep an unexposed duplicate of the type in `DateFormat.Relative.Language` for type signature purposes
 

Note: This builds on #19, the first two commits are in common with it. [6181ece](https://github.com/ryannhg/date-format/commit/6181eceb3a4bfaf07c406ceb9c59027829413e62) is where the actual changes happen.
