### PR TITLE
Fix documentation for dayOfWeekNameAbbreviated

### DIFF
--- a/src/DateFormat.elm
+++ b/src/DateFormat.elm
@@ -242,9 +242,9 @@ dayOfWeekSuffix =
     DayOfWeekSuffix
 
 
-{-| Gets the name of the day of the week, but just the first two letters.
+{-| Gets the name of the day of the week, but just the first three letters.
 
-Examples: `Su, Mo, Tu, ... Fr, Sa`
+Examples: `Sun, Mon, Tue, ... Fri, Sat`
 
 -}
 dayOfWeekNameAbbreviated : Token


### PR DESCRIPTION
The documentation for dayOfWeekNameAbbreviated claims it takes just the first two letters, but in actuality it takes the first three.